### PR TITLE
Refactor extension into src modules

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,10 +9,10 @@
                 "<all_urls>"
             ],
             "js": [
-                "content.js"
+                {"file": "src/content/main.js", "type": "module"}
             ],
             "css": [
-                "style.css"
+                "src/styles/prompts.css"
             ]
         }
     ],

--- a/src/api/prompts.js
+++ b/src/api/prompts.js
@@ -1,0 +1,9 @@
+export async function fetchPrompts() {
+    // For now just return some static prompts. In a real extension this could
+    // fetch from storage or a remote service.
+    return [
+        "Explain this code",
+        "Summarize the following text",
+        "Write an email reply"
+    ];
+}

--- a/src/content/detectPrompt.js
+++ b/src/content/detectPrompt.js
@@ -1,4 +1,4 @@
-function isPromptLikeEditableDiv(el) {
+export function isPromptLikeEditableDiv(el) {
     const contentEditable = el.getAttribute("contenteditable") === "true";
     const roleTextbox = el.getAttribute("role") === "textbox";
     const ariaLabel = el.getAttribute("aria-label")?.toLowerCase() || "";
@@ -16,16 +16,3 @@ function isPromptLikeEditableDiv(el) {
             roleTextbox)
     );
 }
-
-function highlightAllPromptFields() {
-    const fields = document.querySelectorAll('div[contenteditable="true"]');
-    fields.forEach(el => {
-        if (isPromptLikeEditableDiv(el)) {
-            el.style.backgroundColor = "#fff5cc";
-            el.style.border = "2px solid orange";
-        }
-    });
-}
-// Run on load and periodically (in case of dynamic SPAs like ChatGPT)
-
-setInterval(highlightAllPromptFields, 2000);

--- a/src/content/main.js
+++ b/src/content/main.js
@@ -1,0 +1,15 @@
+import { isPromptLikeEditableDiv } from './detectPrompt.js';
+import { fetchPrompts } from '../api/prompts.js';
+import { highlightPromptFields, renderSuggestions } from './ui.js';
+
+async function processFields() {
+    const prompts = await fetchPrompts();
+    const fields = Array.from(document.querySelectorAll('div[contenteditable="true"]'))
+        .filter(isPromptLikeEditableDiv);
+
+    highlightPromptFields(fields);
+    fields.forEach(el => renderSuggestions(el, prompts));
+}
+
+processFields();
+setInterval(processFields, 2000);

--- a/src/content/ui.js
+++ b/src/content/ui.js
@@ -1,0 +1,21 @@
+export function highlightPromptFields(fields) {
+    fields.forEach(el => {
+        el.classList.add('prompt-field');
+    });
+}
+
+export function renderSuggestions(el, prompts) {
+    const list = document.createElement('ul');
+    list.className = 'prompt-suggestions';
+
+    prompts.forEach(text => {
+        const li = document.createElement('li');
+        li.textContent = text;
+        li.addEventListener('click', () => {
+            el.textContent = text;
+        });
+        list.appendChild(li);
+    });
+
+    el.parentElement.appendChild(list);
+}

--- a/src/styles/prompts.css
+++ b/src/styles/prompts.css
@@ -1,0 +1,23 @@
+.prompt-field {
+    background-color: #fff5cc !important;
+    border: 2px solid orange !important;
+}
+
+.prompt-suggestions {
+    list-style: none;
+    margin: 4px 0 0 0;
+    padding: 0;
+    background: white;
+    border: 1px solid #ccc;
+    max-width: 200px;
+    font-size: 14px;
+}
+
+.prompt-suggestions li {
+    padding: 2px 6px;
+    cursor: pointer;
+}
+
+.prompt-suggestions li:hover {
+    background: #eee;
+}

--- a/style.css
+++ b/style.css
@@ -1,4 +1,0 @@
-.prompt-field {
-    background-color: #fff5cc !important;
-    border: 2px solid orange !important;
-}


### PR DESCRIPTION
## Summary
- organize extension into `src/` directories
- move detection logic to `src/content/detectPrompt.js`
- implement new `main.js` that fetches prompts and renders UI
- add simple prompt API and UI helpers
- migrate stylesheet to `src/styles/prompts.css`
- update `manifest.json` for new entrypoints

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6855d01e12c08330b000ee0439f6cdca